### PR TITLE
Change Audio-Streamer dependence to Organization repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "moment": "^2.19.3",
-    "react-native-audio-streamer": "^0.0.9",
+    "react-native-audio-streamer": "https://github.com/App2Sales/react-native-audio-streamer/tarball/master",
     "react-native-music-control": "^0.4.13",
     "react-native-sound": "^0.10.4"
   },


### PR DESCRIPTION
Fix iOS header import

Since react native version 0.40.0, iOS import headers change to <React/HeaderName.h>.